### PR TITLE
Introducing the segmentation ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ def mine_trips(person):
 * Avradip Sen
 * Lukas Vorwerk
 * Leonardo Tonetto
+* Malintha Adikari

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tripmining',
-    version='0.5.0',
+    version='0.5.1',
     include_package_data=True,
     packages=find_packages(include=["tripmining.model", "tripmining.geo", "tripmining.preprocessing",
                                     "tripmining.preprocessing.parser", "tripmining.dataset"],

--- a/tripmining/model/location.py
+++ b/tripmining/model/location.py
@@ -29,7 +29,7 @@ class Location:
         if self is other:
             return True
         if isinstance(other, self.__class__):
-            if self.location_id == other.location_id:
+            if self.name == other.name:  # only for the foursquare dataset
                 return True
             if self.lat != other.lat:
                 return False

--- a/tripmining/model/location.py
+++ b/tripmining/model/location.py
@@ -29,8 +29,8 @@ class Location:
         if self is other:
             return True
         if isinstance(other, self.__class__):
-            if self.location_id != other.location_id:
-                return False
+            if self.location_id == other.location_id:
+                return True
             if self.lat != other.lat:
                 return False
             if self.lng != other.lng:

--- a/tripmining/model/location.py
+++ b/tripmining/model/location.py
@@ -6,16 +6,21 @@ from tripmining.model.coordinate import Coordinate
 
 class Location:
     """
-    A place where users can check in.
+    A place than can be visited by users.
+
+    Nope that blocks are segmented by comparing location ids.
+    Optionally, one can assign a `segmentation_id` based on which the segmentation can be done as well.
     """
 
-    def __init__(self, location_id: str, coordinate: Coordinate, country_code: str, category: str = '', geonames_id: str = '', name: str = ''):
+    def __init__(self, location_id: str, coordinate: Coordinate, country_code: str, category: str = '', geonames_id: str = '', segmentation_id='',
+                 name: str = ''):
         self.location_id = location_id
         self.lat = coordinate.lat
         self.lng = coordinate.lng
         self.country_code = country_code
         self.category = category
         self.geonames_id = geonames_id
+        self.segmentation_id = segmentation_id
         self.name = name
 
     def __hash__(self) -> int:
@@ -29,15 +34,8 @@ class Location:
         if self is other:
             return True
         if isinstance(other, self.__class__):
-            if self.name == other.name:  # only for the foursquare dataset
+            if self.segmentation_id and self.segmentation_id == other.segmentation_id:
+                # the segmentation ID is used for combining different checkins in a larger area, e.g., combining multiple checkins in a city into one block
                 return True
-            if self.lat != other.lat:
-                return False
-            if self.lng != other.lng:
-                return False
-            if self.category != other.category:
-                return False
-            if self.country_code != other.country_code:
-                return False
-            return True
+            return self.location_id == other.location_id
         return False


### PR DESCRIPTION
The idea is that segmentation (i.e., checking if two locations are the same) should not depend on the strict equality of the locations, since one might want to combine several locations within a city into one block. Thus, we introduced a `segmentation_id` based on which the locations/checkins are segmented.